### PR TITLE
🔧 chore(release.yml): update Node.js version to 18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: 18
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
The Node.js version in the release workflow has been updated from 14 to 18. This ensures that the project is using the latest version of Node.js, which may include performance improvements, bug fixes, and new features.