### PR TITLE
🔧 chore(release.yml): update GH_TOKEN environment variable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,5 +23,5 @@ jobs:
 
       - name: Run Semantic Release
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }} # GitHub token
+          GH_TOKEN: $(GH_TOKEN)
         run: npx semantic-release

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"@formkit/auto-animate": "^0.7.0",
-				"archiver": "^6.0.0",
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"vite-plugin-css-injected-by-js": "^3.1.1",
@@ -32,6 +31,7 @@
 				"@typescript-eslint/eslint-plugin": "^5.49.0",
 				"@typescript-eslint/parser": "^5.49.0",
 				"@vitejs/plugin-react-swc": "^3.0.1",
+				"archiver": "^6.0.0",
 				"autoprefixer": "^10.4.13",
 				"eslint": "^8.32.0",
 				"eslint-config-prettier": "^8.8.0",
@@ -2194,6 +2194,7 @@
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/archiver/-/archiver-6.0.0.tgz",
 			"integrity": "sha512-EPGa+bYaxaMiCT8DCbEDqFz8IjeBSExrJzyUOJx2FBkFJ/OZzJuso3lMSk901M50gMqXxTQcumlGajOFlXhVhw==",
+			"dev": true,
 			"dependencies": {
 				"archiver-utils": "^3.0.0",
 				"async": "^3.2.4",
@@ -2211,6 +2212,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.3.tgz",
 			"integrity": "sha512-fXzpEZTKgBJMWy0eUT0/332CAQnJ27OJd7sGcvNZzxS2Yzg7iITivMhXOm+zUTO4vT8ZqlPCqiaLPmB8qWhWRA==",
+			"dev": true,
 			"dependencies": {
 				"glob": "^7.1.4",
 				"graceful-fs": "^4.2.0",
@@ -2231,6 +2233,7 @@
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
 			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -2244,6 +2247,7 @@
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
 			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -2394,7 +2398,8 @@
 		"node_modules/async": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
+			"integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+			"dev": true
 		},
 		"node_modules/autoprefixer": {
 			"version": "10.4.14",
@@ -2462,12 +2467,14 @@
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true
 		},
 		"node_modules/base64-js": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
 			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2502,6 +2509,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
 			"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+			"dev": true,
 			"dependencies": {
 				"buffer": "^5.5.0",
 				"inherits": "^2.0.4",
@@ -2512,6 +2520,7 @@
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
 			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -2531,6 +2540,7 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0",
 				"concat-map": "0.0.1"
@@ -2584,6 +2594,7 @@
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
 			"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -2607,6 +2618,7 @@
 			"version": "0.2.13",
 			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
 			"integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+			"dev": true,
 			"engines": {
 				"node": "*"
 			}
@@ -2835,6 +2847,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.1.tgz",
 			"integrity": "sha512-QLdDLCKNV2dtoTorqgxngQCMA+gWXkM/Nwu7FpeBhk/RdkzimqC3jueb/FDmaZeXh+uby1jkBqE3xArsLBE5wQ==",
+			"dev": true,
 			"dependencies": {
 				"buffer-crc32": "^0.2.13",
 				"crc32-stream": "^4.0.2",
@@ -2849,6 +2862,7 @@
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
 			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -2861,7 +2875,8 @@
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"dev": true
 		},
 		"node_modules/config-chain": {
 			"version": "1.1.13",
@@ -2952,7 +2967,8 @@
 		"node_modules/core-util-is": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+			"integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+			"dev": true
 		},
 		"node_modules/cosmiconfig": {
 			"version": "8.2.0",
@@ -2976,6 +2992,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
 			"integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+			"dev": true,
 			"bin": {
 				"crc32": "bin/crc32.njs"
 			},
@@ -2987,6 +3004,7 @@
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.2.tgz",
 			"integrity": "sha512-DxFZ/Hk473b/muq1VJ///PMNLj0ZMnzye9thBpmjpJKCc5eMgB95aK8zCGrGfQ90cWo561Te6HK9D+j4KPdM6w==",
+			"dev": true,
 			"dependencies": {
 				"crc-32": "^1.2.0",
 				"readable-stream": "^3.4.0"
@@ -2999,6 +3017,7 @@
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
 			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -3287,6 +3306,7 @@
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
 			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"dev": true,
 			"dependencies": {
 				"once": "^1.4.0"
 			}
@@ -4243,7 +4263,8 @@
 		"node_modules/fs-constants": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+			"dev": true
 		},
 		"node_modules/fs-extra": {
 			"version": "11.1.1",
@@ -4262,7 +4283,8 @@
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
+			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"dev": true
 		},
 		"node_modules/fsevents": {
 			"version": "2.3.2",
@@ -4389,6 +4411,7 @@
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
 			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+			"dev": true,
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
 				"inflight": "^1.0.4",
@@ -4481,7 +4504,8 @@
 		"node_modules/graceful-fs": {
 			"version": "4.2.11",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
+			"integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+			"dev": true
 		},
 		"node_modules/grapheme-splitter": {
 			"version": "1.0.4",
@@ -4678,6 +4702,7 @@
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
 			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -4758,6 +4783,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"dev": true,
 			"dependencies": {
 				"once": "^1.3.0",
 				"wrappy": "1"
@@ -4766,7 +4792,8 @@
 		"node_modules/inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
 		},
 		"node_modules/ini": {
 			"version": "1.3.8",
@@ -5369,6 +5396,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
 			"integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+			"dev": true,
 			"dependencies": {
 				"readable-stream": "^2.0.5"
 			},
@@ -5477,12 +5505,14 @@
 		"node_modules/lodash.defaults": {
 			"version": "4.2.0",
 			"resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
-			"integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ=="
+			"integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+			"dev": true
 		},
 		"node_modules/lodash.difference": {
 			"version": "4.5.0",
 			"resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
-			"integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA=="
+			"integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+			"dev": true
 		},
 		"node_modules/lodash.escaperegexp": {
 			"version": "4.1.2",
@@ -5493,7 +5523,8 @@
 		"node_modules/lodash.flatten": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
-			"integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g=="
+			"integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+			"dev": true
 		},
 		"node_modules/lodash.ismatch": {
 			"version": "4.4.0",
@@ -5504,7 +5535,8 @@
 		"node_modules/lodash.isplainobject": {
 			"version": "4.0.6",
 			"resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA=="
+			"integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+			"dev": true
 		},
 		"node_modules/lodash.isstring": {
 			"version": "4.0.1",
@@ -5521,7 +5553,8 @@
 		"node_modules/lodash.union": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
-			"integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw=="
+			"integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+			"dev": true
 		},
 		"node_modules/lodash.uniqby": {
 			"version": "4.7.0",
@@ -5842,6 +5875,7 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
 			"dependencies": {
 				"brace-expansion": "^1.1.7"
 			},
@@ -6067,6 +6101,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 			"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -6261,6 +6296,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
 			"integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -6270,6 +6306,7 @@
 		},
 		"node_modules/npm/node_modules/@isaacs/cliui": {
 			"version": "8.0.2",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -6286,6 +6323,7 @@
 		},
 		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
 			"version": "6.0.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -6299,11 +6337,13 @@
 			"version": "9.2.2",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
 			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
 			"version": "5.1.2",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6320,6 +6360,7 @@
 		},
 		"node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
 			"version": "7.1.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6334,11 +6375,13 @@
 		},
 		"node_modules/npm/node_modules/@isaacs/string-locale-compare": {
 			"version": "1.1.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/@npmcli/arborist": {
 			"version": "6.3.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -6385,6 +6428,7 @@
 		},
 		"node_modules/npm/node_modules/@npmcli/config": {
 			"version": "6.2.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -6403,6 +6447,7 @@
 		},
 		"node_modules/npm/node_modules/@npmcli/disparity-colors": {
 			"version": "3.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -6414,6 +6459,7 @@
 		},
 		"node_modules/npm/node_modules/@npmcli/fs": {
 			"version": "3.1.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -6425,6 +6471,7 @@
 		},
 		"node_modules/npm/node_modules/@npmcli/git": {
 			"version": "4.1.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -6443,6 +6490,7 @@
 		},
 		"node_modules/npm/node_modules/@npmcli/installed-package-contents": {
 			"version": "2.0.2",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -6458,6 +6506,7 @@
 		},
 		"node_modules/npm/node_modules/@npmcli/map-workspaces": {
 			"version": "3.0.4",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -6472,6 +6521,7 @@
 		},
 		"node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
 			"version": "5.0.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -6486,6 +6536,7 @@
 		},
 		"node_modules/npm/node_modules/@npmcli/name-from-folder": {
 			"version": "2.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
@@ -6494,6 +6545,7 @@
 		},
 		"node_modules/npm/node_modules/@npmcli/node-gyp": {
 			"version": "3.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
@@ -6502,6 +6554,7 @@
 		},
 		"node_modules/npm/node_modules/@npmcli/package-json": {
 			"version": "4.0.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -6519,6 +6572,7 @@
 		},
 		"node_modules/npm/node_modules/@npmcli/promise-spawn": {
 			"version": "6.0.2",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -6530,6 +6584,7 @@
 		},
 		"node_modules/npm/node_modules/@npmcli/query": {
 			"version": "3.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -6541,6 +6596,7 @@
 		},
 		"node_modules/npm/node_modules/@npmcli/run-script": {
 			"version": "6.0.2",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -6556,6 +6612,7 @@
 		},
 		"node_modules/npm/node_modules/@pkgjs/parseargs": {
 			"version": "0.11.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -6565,6 +6622,7 @@
 		},
 		"node_modules/npm/node_modules/@sigstore/protobuf-specs": {
 			"version": "0.1.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -6573,6 +6631,7 @@
 		},
 		"node_modules/npm/node_modules/@sigstore/tuf": {
 			"version": "1.0.2",
+			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -6585,6 +6644,7 @@
 		},
 		"node_modules/npm/node_modules/@tootallnate/once": {
 			"version": "2.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -6593,6 +6653,7 @@
 		},
 		"node_modules/npm/node_modules/@tufjs/canonical-json": {
 			"version": "1.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -6601,6 +6662,7 @@
 		},
 		"node_modules/npm/node_modules/@tufjs/models": {
 			"version": "1.0.4",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6613,6 +6675,7 @@
 		},
 		"node_modules/npm/node_modules/abbrev": {
 			"version": "2.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
@@ -6621,6 +6684,7 @@
 		},
 		"node_modules/npm/node_modules/abort-controller": {
 			"version": "3.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6632,6 +6696,7 @@
 		},
 		"node_modules/npm/node_modules/agent-base": {
 			"version": "6.0.2",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6643,6 +6708,7 @@
 		},
 		"node_modules/npm/node_modules/agentkeepalive": {
 			"version": "4.3.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6658,6 +6724,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
 			"integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6672,6 +6739,7 @@
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -6682,6 +6750,7 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6696,16 +6765,19 @@
 		},
 		"node_modules/npm/node_modules/aproba": {
 			"version": "2.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/archy": {
 			"version": "1.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/are-we-there-yet": {
 			"version": "4.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -6720,6 +6792,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
@@ -6727,6 +6800,7 @@
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
 			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -6746,6 +6820,7 @@
 		},
 		"node_modules/npm/node_modules/bin-links": {
 			"version": "4.0.2",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -6760,6 +6835,7 @@
 		},
 		"node_modules/npm/node_modules/binary-extensions": {
 			"version": "2.2.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -6770,6 +6846,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
 			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6778,6 +6855,7 @@
 		},
 		"node_modules/npm/node_modules/buffer": {
 			"version": "6.0.3",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -6801,6 +6879,7 @@
 		},
 		"node_modules/npm/node_modules/builtins": {
 			"version": "5.0.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6809,6 +6888,7 @@
 		},
 		"node_modules/npm/node_modules/cacache": {
 			"version": "17.1.3",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -6831,6 +6911,7 @@
 		},
 		"node_modules/npm/node_modules/chalk": {
 			"version": "5.3.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -6842,6 +6923,7 @@
 		},
 		"node_modules/npm/node_modules/chownr": {
 			"version": "2.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
@@ -6850,6 +6932,7 @@
 		},
 		"node_modules/npm/node_modules/ci-info": {
 			"version": "3.8.0",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -6864,6 +6947,7 @@
 		},
 		"node_modules/npm/node_modules/cidr-regex": {
 			"version": "3.1.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
@@ -6877,6 +6961,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
 			"integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -6885,6 +6970,7 @@
 		},
 		"node_modules/npm/node_modules/cli-columns": {
 			"version": "4.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6899,6 +6985,7 @@
 			"version": "0.6.3",
 			"resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
 			"integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6913,6 +7000,7 @@
 		},
 		"node_modules/npm/node_modules/clone": {
 			"version": "1.0.4",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -6921,6 +7009,7 @@
 		},
 		"node_modules/npm/node_modules/cmd-shim": {
 			"version": "6.0.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
@@ -6931,6 +7020,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6944,11 +7034,13 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/color-support": {
 			"version": "1.1.3",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"bin": {
@@ -6957,6 +7049,7 @@
 		},
 		"node_modules/npm/node_modules/columnify": {
 			"version": "1.6.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6969,6 +7062,7 @@
 		},
 		"node_modules/npm/node_modules/common-ancestor-path": {
 			"version": "1.0.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC"
 		},
@@ -6976,16 +7070,19 @@
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/console-control-strings": {
 			"version": "1.1.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/cross-spawn": {
 			"version": "7.0.3",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6999,6 +7096,7 @@
 		},
 		"node_modules/npm/node_modules/cross-spawn/node_modules/which": {
 			"version": "2.0.2",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7015,6 +7113,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
 			"integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"bin": {
@@ -7028,6 +7127,7 @@
 			"version": "4.3.4",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
 			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7044,11 +7144,13 @@
 		},
 		"node_modules/npm/node_modules/debug/node_modules/ms": {
 			"version": "2.1.2",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/defaults": {
 			"version": "1.0.4",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7060,11 +7162,13 @@
 		},
 		"node_modules/npm/node_modules/delegates": {
 			"version": "1.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/depd": {
 			"version": "2.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -7073,6 +7177,7 @@
 		},
 		"node_modules/npm/node_modules/diff": {
 			"version": "5.1.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "BSD-3-Clause",
 			"engines": {
@@ -7081,6 +7186,7 @@
 		},
 		"node_modules/npm/node_modules/eastasianwidth": {
 			"version": "0.2.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
@@ -7088,11 +7194,13 @@
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
 			"integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/encoding": {
 			"version": "0.1.13",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -7102,6 +7210,7 @@
 		},
 		"node_modules/npm/node_modules/env-paths": {
 			"version": "2.2.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -7110,11 +7219,13 @@
 		},
 		"node_modules/npm/node_modules/err-code": {
 			"version": "2.0.3",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/event-target-shim": {
 			"version": "5.0.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -7123,6 +7234,7 @@
 		},
 		"node_modules/npm/node_modules/events": {
 			"version": "3.3.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -7131,11 +7243,13 @@
 		},
 		"node_modules/npm/node_modules/exponential-backoff": {
 			"version": "3.1.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0"
 		},
 		"node_modules/npm/node_modules/fastest-levenshtein": {
 			"version": "1.0.16",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -7144,6 +7258,7 @@
 		},
 		"node_modules/npm/node_modules/foreground-child": {
 			"version": "3.1.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7159,6 +7274,7 @@
 		},
 		"node_modules/npm/node_modules/fs-minipass": {
 			"version": "3.0.2",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7172,6 +7288,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC"
 		},
@@ -7179,11 +7296,13 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/gauge": {
 			"version": "5.0.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7202,6 +7321,7 @@
 		},
 		"node_modules/npm/node_modules/glob": {
 			"version": "10.2.7",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7223,6 +7343,7 @@
 		},
 		"node_modules/npm/node_modules/graceful-fs": {
 			"version": "4.2.11",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC"
 		},
@@ -7230,6 +7351,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
 			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7241,11 +7363,13 @@
 		},
 		"node_modules/npm/node_modules/has-unicode": {
 			"version": "2.0.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/hosted-git-info": {
 			"version": "6.1.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7257,11 +7381,13 @@
 		},
 		"node_modules/npm/node_modules/http-cache-semantics": {
 			"version": "4.1.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/npm/node_modules/http-proxy-agent": {
 			"version": "5.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7275,6 +7401,7 @@
 		},
 		"node_modules/npm/node_modules/https-proxy-agent": {
 			"version": "5.0.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7287,6 +7414,7 @@
 		},
 		"node_modules/npm/node_modules/humanize-ms": {
 			"version": "1.2.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7295,6 +7423,7 @@
 		},
 		"node_modules/npm/node_modules/iconv-lite": {
 			"version": "0.6.3",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true,
@@ -7307,6 +7436,7 @@
 		},
 		"node_modules/npm/node_modules/ieee754": {
 			"version": "1.2.1",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -7326,6 +7456,7 @@
 		},
 		"node_modules/npm/node_modules/ignore-walk": {
 			"version": "6.0.3",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7339,6 +7470,7 @@
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -7349,6 +7481,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
 			"integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -7359,6 +7492,7 @@
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7370,11 +7504,13 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/ini": {
 			"version": "4.1.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
@@ -7383,6 +7519,7 @@
 		},
 		"node_modules/npm/node_modules/init-package-json": {
 			"version": "5.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7400,11 +7537,13 @@
 		},
 		"node_modules/npm/node_modules/ip": {
 			"version": "2.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/ip-regex": {
 			"version": "4.3.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -7413,6 +7552,7 @@
 		},
 		"node_modules/npm/node_modules/is-cidr": {
 			"version": "4.0.2",
+			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
@@ -7426,6 +7566,7 @@
 			"version": "2.12.1",
 			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
 			"integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7439,6 +7580,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
 			"integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -7447,6 +7589,7 @@
 		},
 		"node_modules/npm/node_modules/is-lambda": {
 			"version": "1.0.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
@@ -7454,11 +7597,13 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/jackspeak": {
 			"version": "2.2.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
@@ -7478,6 +7623,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.0.tgz",
 			"integrity": "sha512-iZbGHafX/59r39gPwVPRBGw0QQKnA7tte5pSMrhWOW7swGsVvVTjmfyAV9pNqk8YGT7tRCdxRu8uzcgZwoDooA==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -7486,6 +7632,7 @@
 		},
 		"node_modules/npm/node_modules/json-stringify-nice": {
 			"version": "1.1.4",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"funding": {
@@ -7494,6 +7641,7 @@
 		},
 		"node_modules/npm/node_modules/jsonparse": {
 			"version": "1.3.1",
+			"dev": true,
 			"engines": [
 				"node >= 0.2.0"
 			],
@@ -7502,16 +7650,19 @@
 		},
 		"node_modules/npm/node_modules/just-diff": {
 			"version": "6.0.2",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/just-diff-apply": {
 			"version": "5.5.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/libnpmaccess": {
 			"version": "7.0.2",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7524,6 +7675,7 @@
 		},
 		"node_modules/npm/node_modules/libnpmdiff": {
 			"version": "5.0.19",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7543,6 +7695,7 @@
 		},
 		"node_modules/npm/node_modules/libnpmexec": {
 			"version": "6.0.3",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7564,6 +7717,7 @@
 		},
 		"node_modules/npm/node_modules/libnpmfund": {
 			"version": "4.0.19",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7575,6 +7729,7 @@
 		},
 		"node_modules/npm/node_modules/libnpmhook": {
 			"version": "9.0.3",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7587,6 +7742,7 @@
 		},
 		"node_modules/npm/node_modules/libnpmorg": {
 			"version": "5.0.4",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7599,6 +7755,7 @@
 		},
 		"node_modules/npm/node_modules/libnpmpack": {
 			"version": "5.0.19",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7613,6 +7770,7 @@
 		},
 		"node_modules/npm/node_modules/libnpmpublish": {
 			"version": "7.5.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7631,6 +7789,7 @@
 		},
 		"node_modules/npm/node_modules/libnpmsearch": {
 			"version": "6.0.2",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7642,6 +7801,7 @@
 		},
 		"node_modules/npm/node_modules/libnpmteam": {
 			"version": "5.0.3",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7654,6 +7814,7 @@
 		},
 		"node_modules/npm/node_modules/libnpmversion": {
 			"version": "4.0.2",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7669,6 +7830,7 @@
 		},
 		"node_modules/npm/node_modules/lru-cache": {
 			"version": "7.18.3",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
@@ -7677,6 +7839,7 @@
 		},
 		"node_modules/npm/node_modules/make-fetch-happen": {
 			"version": "11.1.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7702,6 +7865,7 @@
 		},
 		"node_modules/npm/node_modules/minimatch": {
 			"version": "9.0.3",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7716,6 +7880,7 @@
 		},
 		"node_modules/npm/node_modules/minipass": {
 			"version": "5.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
@@ -7724,6 +7889,7 @@
 		},
 		"node_modules/npm/node_modules/minipass-collect": {
 			"version": "1.0.2",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7735,6 +7901,7 @@
 		},
 		"node_modules/npm/node_modules/minipass-collect/node_modules/minipass": {
 			"version": "3.3.6",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7746,6 +7913,7 @@
 		},
 		"node_modules/npm/node_modules/minipass-fetch": {
 			"version": "3.0.3",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7762,6 +7930,7 @@
 		},
 		"node_modules/npm/node_modules/minipass-flush": {
 			"version": "1.0.5",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7773,6 +7942,7 @@
 		},
 		"node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
 			"version": "3.3.6",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7784,6 +7954,7 @@
 		},
 		"node_modules/npm/node_modules/minipass-json-stream": {
 			"version": "1.0.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7793,6 +7964,7 @@
 		},
 		"node_modules/npm/node_modules/minipass-json-stream/node_modules/minipass": {
 			"version": "3.3.6",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7804,6 +7976,7 @@
 		},
 		"node_modules/npm/node_modules/minipass-pipeline": {
 			"version": "1.2.4",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7815,6 +7988,7 @@
 		},
 		"node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
 			"version": "3.3.6",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7826,6 +8000,7 @@
 		},
 		"node_modules/npm/node_modules/minipass-sized": {
 			"version": "1.0.3",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7837,6 +8012,7 @@
 		},
 		"node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
 			"version": "3.3.6",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7848,6 +8024,7 @@
 		},
 		"node_modules/npm/node_modules/minizlib": {
 			"version": "2.1.2",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7860,6 +8037,7 @@
 		},
 		"node_modules/npm/node_modules/minizlib/node_modules/minipass": {
 			"version": "3.3.6",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7871,6 +8049,7 @@
 		},
 		"node_modules/npm/node_modules/mkdirp": {
 			"version": "1.0.4",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"bin": {
@@ -7882,11 +8061,13 @@
 		},
 		"node_modules/npm/node_modules/ms": {
 			"version": "2.1.3",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/mute-stream": {
 			"version": "1.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
@@ -7895,6 +8076,7 @@
 		},
 		"node_modules/npm/node_modules/negotiator": {
 			"version": "0.6.3",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -7903,6 +8085,7 @@
 		},
 		"node_modules/npm/node_modules/node-gyp": {
 			"version": "9.4.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7927,11 +8110,13 @@
 		},
 		"node_modules/npm/node_modules/node-gyp/node_modules/abbrev": {
 			"version": "1.1.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/node-gyp/node_modules/are-we-there-yet": {
 			"version": "3.0.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7946,6 +8131,7 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7955,6 +8141,7 @@
 		},
 		"node_modules/npm/node_modules/node-gyp/node_modules/gauge": {
 			"version": "4.0.4",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7973,6 +8160,7 @@
 		},
 		"node_modules/npm/node_modules/node-gyp/node_modules/glob": {
 			"version": "7.2.3",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -7994,6 +8182,7 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8005,6 +8194,7 @@
 		},
 		"node_modules/npm/node_modules/node-gyp/node_modules/nopt": {
 			"version": "6.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8019,6 +8209,7 @@
 		},
 		"node_modules/npm/node_modules/node-gyp/node_modules/npmlog": {
 			"version": "6.0.2",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8035,6 +8226,7 @@
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
 			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8050,11 +8242,13 @@
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
 			"integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/node-gyp/node_modules/which": {
 			"version": "2.0.2",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8069,6 +8263,7 @@
 		},
 		"node_modules/npm/node_modules/nopt": {
 			"version": "7.2.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8083,6 +8278,7 @@
 		},
 		"node_modules/npm/node_modules/normalize-package-data": {
 			"version": "5.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
@@ -8097,6 +8293,7 @@
 		},
 		"node_modules/npm/node_modules/npm-audit-report": {
 			"version": "5.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
@@ -8105,6 +8302,7 @@
 		},
 		"node_modules/npm/node_modules/npm-bundled": {
 			"version": "3.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8116,6 +8314,7 @@
 		},
 		"node_modules/npm/node_modules/npm-install-checks": {
 			"version": "6.1.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
@@ -8127,6 +8326,7 @@
 		},
 		"node_modules/npm/node_modules/npm-normalize-package-bin": {
 			"version": "3.0.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
@@ -8135,6 +8335,7 @@
 		},
 		"node_modules/npm/node_modules/npm-package-arg": {
 			"version": "10.1.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8149,6 +8350,7 @@
 		},
 		"node_modules/npm/node_modules/npm-packlist": {
 			"version": "7.0.4",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8160,6 +8362,7 @@
 		},
 		"node_modules/npm/node_modules/npm-pick-manifest": {
 			"version": "8.0.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8174,6 +8377,7 @@
 		},
 		"node_modules/npm/node_modules/npm-profile": {
 			"version": "7.0.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8186,6 +8390,7 @@
 		},
 		"node_modules/npm/node_modules/npm-registry-fetch": {
 			"version": "14.0.5",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8203,6 +8408,7 @@
 		},
 		"node_modules/npm/node_modules/npm-user-validate": {
 			"version": "2.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "BSD-2-Clause",
 			"engines": {
@@ -8211,6 +8417,7 @@
 		},
 		"node_modules/npm/node_modules/npmlog": {
 			"version": "7.0.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8227,6 +8434,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8235,6 +8443,7 @@
 		},
 		"node_modules/npm/node_modules/p-map": {
 			"version": "4.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8249,6 +8458,7 @@
 		},
 		"node_modules/npm/node_modules/pacote": {
 			"version": "15.2.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8280,6 +8490,7 @@
 		},
 		"node_modules/npm/node_modules/parse-conflict-json": {
 			"version": "3.0.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8295,6 +8506,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -8305,6 +8517,7 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -8313,6 +8526,7 @@
 		},
 		"node_modules/npm/node_modules/path-scurry": {
 			"version": "1.9.2",
+			"dev": true,
 			"inBundle": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
@@ -8328,6 +8542,7 @@
 		},
 		"node_modules/npm/node_modules/path-scurry/node_modules/lru-cache": {
 			"version": "9.1.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
@@ -8336,6 +8551,7 @@
 		},
 		"node_modules/npm/node_modules/postcss-selector-parser": {
 			"version": "6.0.13",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8348,6 +8564,7 @@
 		},
 		"node_modules/npm/node_modules/proc-log": {
 			"version": "3.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
@@ -8356,6 +8573,7 @@
 		},
 		"node_modules/npm/node_modules/process": {
 			"version": "0.11.10",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -8364,6 +8582,7 @@
 		},
 		"node_modules/npm/node_modules/promise-all-reject-late": {
 			"version": "1.0.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"funding": {
@@ -8372,6 +8591,7 @@
 		},
 		"node_modules/npm/node_modules/promise-call-limit": {
 			"version": "1.0.2",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"funding": {
@@ -8380,11 +8600,13 @@
 		},
 		"node_modules/npm/node_modules/promise-inflight": {
 			"version": "1.0.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/promise-retry": {
 			"version": "2.0.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8397,6 +8619,7 @@
 		},
 		"node_modules/npm/node_modules/promzard": {
 			"version": "1.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8408,6 +8631,7 @@
 		},
 		"node_modules/npm/node_modules/qrcode-terminal": {
 			"version": "0.12.0",
+			"dev": true,
 			"inBundle": true,
 			"bin": {
 				"qrcode-terminal": "bin/qrcode-terminal.js"
@@ -8415,6 +8639,7 @@
 		},
 		"node_modules/npm/node_modules/read": {
 			"version": "2.1.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8426,6 +8651,7 @@
 		},
 		"node_modules/npm/node_modules/read-cmd-shim": {
 			"version": "4.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
@@ -8434,6 +8660,7 @@
 		},
 		"node_modules/npm/node_modules/read-package-json": {
 			"version": "6.0.4",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8448,6 +8675,7 @@
 		},
 		"node_modules/npm/node_modules/read-package-json-fast": {
 			"version": "3.0.2",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8460,6 +8688,7 @@
 		},
 		"node_modules/npm/node_modules/readable-stream": {
 			"version": "4.4.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8474,6 +8703,7 @@
 		},
 		"node_modules/npm/node_modules/retry": {
 			"version": "0.12.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -8484,6 +8714,7 @@
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8500,6 +8731,7 @@
 			"version": "1.1.11",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8509,6 +8741,7 @@
 		},
 		"node_modules/npm/node_modules/rimraf/node_modules/glob": {
 			"version": "7.2.3",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8530,6 +8763,7 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8541,6 +8775,7 @@
 		},
 		"node_modules/npm/node_modules/safe-buffer": {
 			"version": "5.2.1",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -8560,12 +8795,16 @@
 		},
 		"node_modules/npm/node_modules/safer-buffer": {
 			"version": "2.1.2",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/npm/node_modules/semver": {
 			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8580,6 +8819,7 @@
 		},
 		"node_modules/npm/node_modules/semver/node_modules/lru-cache": {
 			"version": "6.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8591,6 +8831,7 @@
 		},
 		"node_modules/npm/node_modules/set-blocking": {
 			"version": "2.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC"
 		},
@@ -8598,6 +8839,7 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8611,6 +8853,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -8619,6 +8862,7 @@
 		},
 		"node_modules/npm/node_modules/signal-exit": {
 			"version": "4.0.2",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
@@ -8630,6 +8874,7 @@
 		},
 		"node_modules/npm/node_modules/sigstore": {
 			"version": "1.7.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -8646,6 +8891,7 @@
 		},
 		"node_modules/npm/node_modules/smart-buffer": {
 			"version": "4.2.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -8655,6 +8901,7 @@
 		},
 		"node_modules/npm/node_modules/socks": {
 			"version": "2.7.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8668,6 +8915,7 @@
 		},
 		"node_modules/npm/node_modules/socks-proxy-agent": {
 			"version": "7.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8683,6 +8931,7 @@
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
 			"integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -8694,6 +8943,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
 			"integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+			"dev": true,
 			"inBundle": true,
 			"license": "CC-BY-3.0"
 		},
@@ -8701,6 +8951,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
 			"integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8712,11 +8963,13 @@
 			"version": "3.0.13",
 			"resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.13.tgz",
 			"integrity": "sha512-XkD+zwiqXHikFZm4AX/7JSCXA98U5Db4AFd5XUg/+9UNtnH75+Z9KxtpYiJZx36mUDVOwH83pl7yvCer6ewM3w==",
+			"dev": true,
 			"inBundle": true,
 			"license": "CC0-1.0"
 		},
 		"node_modules/npm/node_modules/ssri": {
 			"version": "10.0.4",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8728,6 +8981,7 @@
 		},
 		"node_modules/npm/node_modules/string_decoder": {
 			"version": "1.3.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8738,6 +8992,7 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8752,6 +9007,7 @@
 		"node_modules/npm/node_modules/string-width-cjs": {
 			"name": "string-width",
 			"version": "4.2.3",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8767,6 +9023,7 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8779,6 +9036,7 @@
 		"node_modules/npm/node_modules/strip-ansi-cjs": {
 			"name": "strip-ansi",
 			"version": "6.0.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8790,6 +9048,7 @@
 		},
 		"node_modules/npm/node_modules/supports-color": {
 			"version": "9.4.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -8801,6 +9060,7 @@
 		},
 		"node_modules/npm/node_modules/tar": {
 			"version": "6.1.15",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8817,6 +9077,7 @@
 		},
 		"node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
 			"version": "2.1.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8828,6 +9089,7 @@
 		},
 		"node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
 			"version": "3.3.6",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8839,16 +9101,19 @@
 		},
 		"node_modules/npm/node_modules/text-table": {
 			"version": "0.2.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/tiny-relative-date": {
 			"version": "1.3.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/treeverse": {
 			"version": "3.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"engines": {
@@ -8857,6 +9122,7 @@
 		},
 		"node_modules/npm/node_modules/tuf-js": {
 			"version": "1.1.7",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8870,6 +9136,7 @@
 		},
 		"node_modules/npm/node_modules/unique-filename": {
 			"version": "3.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8881,6 +9148,7 @@
 		},
 		"node_modules/npm/node_modules/unique-slug": {
 			"version": "4.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8894,6 +9162,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
 			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
@@ -8901,6 +9170,7 @@
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
 			"integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+			"dev": true,
 			"inBundle": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -8910,6 +9180,7 @@
 		},
 		"node_modules/npm/node_modules/validate-npm-package-name": {
 			"version": "5.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8921,11 +9192,13 @@
 		},
 		"node_modules/npm/node_modules/walk-up-path": {
 			"version": "3.0.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/wcwidth": {
 			"version": "1.0.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8934,6 +9207,7 @@
 		},
 		"node_modules/npm/node_modules/which": {
 			"version": "3.0.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8948,6 +9222,7 @@
 		},
 		"node_modules/npm/node_modules/wide-align": {
 			"version": "1.1.5",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -8956,6 +9231,7 @@
 		},
 		"node_modules/npm/node_modules/wrap-ansi": {
 			"version": "8.1.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8973,6 +9249,7 @@
 		"node_modules/npm/node_modules/wrap-ansi-cjs": {
 			"name": "wrap-ansi",
 			"version": "7.0.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8989,6 +9266,7 @@
 		},
 		"node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
 			"version": "6.0.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -9000,6 +9278,7 @@
 		},
 		"node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-styles": {
 			"version": "6.2.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"engines": {
@@ -9013,11 +9292,13 @@
 			"version": "9.2.2",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
 			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
 		},
 		"node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
 			"version": "5.1.2",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9034,6 +9315,7 @@
 		},
 		"node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
 			"version": "7.1.0",
+			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9050,11 +9332,13 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC"
 		},
 		"node_modules/npm/node_modules/write-file-atomic": {
 			"version": "5.0.1",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
 			"dependencies": {
@@ -9069,6 +9353,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+			"dev": true,
 			"inBundle": true,
 			"license": "ISC"
 		},
@@ -9207,6 +9492,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+			"dev": true,
 			"dependencies": {
 				"wrappy": "1"
 			}
@@ -9440,6 +9726,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -9752,7 +10039,8 @@
 		"node_modules/process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+			"dev": true
 		},
 		"node_modules/prop-types": {
 			"version": "15.8.1",
@@ -10086,6 +10374,7 @@
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
 			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"dev": true,
 			"dependencies": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -10099,12 +10388,14 @@
 		"node_modules/readable-stream/node_modules/isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"dev": true
 		},
 		"node_modules/readdir-glob": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
 			"integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+			"dev": true,
 			"dependencies": {
 				"minimatch": "^5.1.0"
 			}
@@ -10113,6 +10404,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
 			"integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+			"dev": true,
 			"dependencies": {
 				"balanced-match": "^1.0.0"
 			}
@@ -10121,6 +10413,7 @@
 			"version": "5.1.6",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
 			"integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
+			"dev": true,
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
 			},
@@ -10298,7 +10591,8 @@
 		"node_modules/safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+			"dev": true
 		},
 		"node_modules/safe-regex-test": {
 			"version": "1.0.0",
@@ -10584,9 +10878,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.5.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz",
-			"integrity": "sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==",
+			"version": "7.5.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 			"dev": true,
 			"dependencies": {
 				"lru-cache": "^6.0.0"
@@ -10895,6 +11189,7 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
 			"dependencies": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -11158,6 +11453,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
 			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+			"dev": true,
 			"dependencies": {
 				"bl": "^4.0.3",
 				"end-of-stream": "^1.4.1",
@@ -11173,6 +11469,7 @@
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
 			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",
@@ -11584,7 +11881,8 @@
 		"node_modules/util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+			"integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+			"dev": true
 		},
 		"node_modules/v8-compile-cache-lib": {
 			"version": "3.0.1",
@@ -11763,7 +12061,8 @@
 		"node_modules/wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+			"integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+			"dev": true
 		},
 		"node_modules/xtend": {
 			"version": "4.0.2",
@@ -11859,6 +12158,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.0.tgz",
 			"integrity": "sha512-zshzwQW7gG7hjpBlgeQP9RuyPGNxvJdzR8SUM3QhxCnLjWN2E7j3dOvpeDcQoETfHx0urRS7EtmVToql7YpU4A==",
+			"dev": true,
 			"dependencies": {
 				"archiver-utils": "^2.1.0",
 				"compress-commons": "^4.1.0",
@@ -11872,6 +12172,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
 			"integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+			"dev": true,
 			"dependencies": {
 				"glob": "^7.1.4",
 				"graceful-fs": "^4.2.0",
@@ -11892,6 +12193,7 @@
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
 			"integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+			"dev": true,
 			"dependencies": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -11905,12 +12207,14 @@
 		"node_modules/zip-stream/node_modules/isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+			"integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+			"dev": true
 		},
 		"node_modules/zip-stream/node_modules/readable-stream": {
 			"version": "3.6.2",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
 			"integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+			"dev": true,
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"string_decoder": "^1.1.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
 	"type": "module",
 	"dependencies": {
 		"@formkit/auto-animate": "^0.7.0",
-		"archiver": "^6.0.0",
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"vite-plugin-css-injected-by-js": "^3.1.1",
@@ -42,6 +41,7 @@
 		"@typescript-eslint/eslint-plugin": "^5.49.0",
 		"@typescript-eslint/parser": "^5.49.0",
 		"@vitejs/plugin-react-swc": "^3.0.1",
+		"archiver": "^6.0.0",
 		"autoprefixer": "^10.4.13",
 		"eslint": "^8.32.0",
 		"eslint-config-prettier": "^8.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4814,15 +4814,10 @@ semver@^6.3.0:
   resolved "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
 
-semver@^7.0.0, semver@^7.1.2, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7:
-  version "7.5.1"
-  resolved "https://registry.npmjs.org/semver/-/semver-7.5.1.tgz"
-  integrity sha512-Wvss5ivl8TMRZXXESstBA4uR5iXgEN/VC5/sOcuXdVLzcdkz4HWetIoRfG5gb5X+ij/G9rw9YoGn3QoQ8OCSpw==
-  dependencies:
-    lru-cache "^6.0.0"
-
-semver@^7.1.1, semver@^7.5.3, semver@^7.5.4:
+semver@^7.0.0, semver@^7.1.1, semver@^7.1.2, semver@^7.3.2, semver@^7.3.4, semver@^7.3.5, semver@^7.3.7, semver@^7.5.3, semver@^7.5.4:
   version "7.5.4"
+  resolved "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz"
+  integrity sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
🔧 chore(package.json): update archiver dependency version The GH_TOKEN environment variable in the release.yml workflow file has been updated to use the $(GH_TOKEN) syntax instead of ${{ secrets.GH_TOKEN }}. This change allows for better compatibility with different versions of GitHub Actions. Additionally, the archiver dependency version in the package.json file has been updated to version 6.0.0 to ensure compatibility with other dependencies.