### PR TITLE
🔒 chore(release.yml): update GH_TOKEN environment variable to use sec…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,5 +23,5 @@ jobs:
 
       - name: Run Semantic Release
         env:
-          GH_TOKEN: $(GH_TOKEN)
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
         run: npx semantic-release

--- a/package-lock.json
+++ b/package-lock.json
@@ -7096,6 +7096,8 @@
 		},
 		"node_modules/npm/node_modules/cross-spawn/node_modules/which": {
 			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -7144,6 +7146,8 @@
 		},
 		"node_modules/npm/node_modules/debug/node_modules/ms": {
 			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT"
@@ -8160,6 +8164,8 @@
 		},
 		"node_modules/npm/node_modules/node-gyp/node_modules/glob": {
 			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -8741,6 +8747,8 @@
 		},
 		"node_modules/npm/node_modules/rimraf/node_modules/glob": {
 			"version": "7.2.3",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",
@@ -8819,6 +8827,8 @@
 		},
 		"node_modules/npm/node_modules/semver/node_modules/lru-cache": {
 			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 			"dev": true,
 			"inBundle": true,
 			"license": "ISC",


### PR DESCRIPTION
…rets.GITHUB_TOKEN

The GH_TOKEN environment variable has been updated to use the secrets.GITHUB_TOKEN. This ensures that the GitHub token is securely stored and not exposed in the workflow file.