### PR TITLE
🔒 chore(release.yml): add write-all permissions to the release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   release:
+    permissions: write-all
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
The release job now has the write-all permissions, which allows it to perform write operations on all repositories in the organization. This change was made to ensure that the release job has the necessary permissions to perform its tasks effectively.