### PR TITLE
🔧 chore(release.yml): update package.json Version script

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
 
       - name: Update package.json Version
         run: |
+          set -x
           # Install Semantic Release and extract the new version
           semantic_release_output=$(npx semantic-release --dry-run)
           no_new_version=$(echo "$semantic_release_output" | grep -oP "There are no relevant changes, so no new version is released")
@@ -30,7 +31,7 @@ jobs:
 
           if [ -n "$no_new_version" ]; then
             echo "No new version is released"
-            exit
+            exit 0
           fi
 
           if [ -z "$new_version" ]; then


### PR DESCRIPTION
The script for updating the package.json Version has been modified to include the 'set -x' command. This command enables the printing of each command before it is executed, providing better visibility into the execution process. Additionally, the 'exit' command has been changed to 'exit 0' to explicitly indicate a successful exit status when there are no relevant changes and no new version is released.