### PR TITLE
🐛 fix(release.yml): redirect stderr to stdout when running semantic-r…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,18 +25,18 @@ jobs:
         run: |
           set -x
           # Install Semantic Release and extract the new version
-          semantic_release_output=$(npx semantic-release --dry-run)
-          no_new_version=$(echo "$semantic_release_output" | grep -oP "There are no relevant changes, so no new version is released")
+          semantic_release_output=$(npx semantic-release --dry-run 2>&1)
+          no_new_version=$(echo "$semantic_release_output" | grep -o "There are no relevant changes, so no new version is released")
           new_version=$(echo "$semantic_release_output" | grep -oP 'The next release version is \K\d+\.\d+\.\d+')
 
           if [ -n "$no_new_version" ]; then
-            echo "No new version is released"
-            exit 0
+              echo "No new version is released"
+              exit 0
           fi
 
           if [ -z "$new_version" ]; then
-            echo "Failed to extract the new version from Semantic Release output."
-            exit 1
+              echo "Failed to extract the new version from Semantic Release output."
+              exit 1
           fi
 
           # Use npm version to update the package.json


### PR DESCRIPTION
…elease

✨ feat(release.yml): improve error handling and messaging when no new version is released or when failed to extract the new version The fix redirects the stderr output to stdout when running the semantic-release command to capture the error message. This ensures that the error message is included in the semantic_release_output variable. The feature adds improved error handling and messaging when there are no relevant changes and no new version is released or when the new version cannot be extracted from the semantic-release output. This provides better feedback and clarity in the release workflow.