### PR TITLE
🐛 fix(release.yml): handle case when new version cannot be extracted …

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,20 +23,19 @@ jobs:
 
       - name: Update package.json Version
         run: |
-          set -x
           # Install Semantic Release and extract the new version
           semantic_release_output=$(npx semantic-release --dry-run 2>&1)
           no_new_version=$(echo "$semantic_release_output" | grep -o "There are no relevant changes, so no new version is released")
           new_version=$(echo "$semantic_release_output" | grep -oP 'The next release version is \K\d+\.\d+\.\d+')
-
+          set -x
           if [ -n "$no_new_version" ]; then
               echo "No new version is released"
               exit 0
           fi
 
           if [ -z "$new_version" ]; then
-              echo "Failed to extract the new version from Semantic Release output."
-              exit 1
+              echo "Failed to extract the new version from Semantic Release output. Leaving the version how it is"
+              exit 0
           fi
 
           # Use npm version to update the package.json


### PR DESCRIPTION
…from Semantic Release output

The script now handles the case when the new version cannot be extracted from the Semantic Release output. Instead of exiting with an error, it now prints a message indicating the failure and exits with a success status code. This ensures that the version remains unchanged in such cases.