### PR TITLE
🔧 chore: remove redirection of stderr to stdout in semantic-release command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Update package.json Version
         run: |
           # Install Semantic Release and extract the new version
-          semantic_release_output=$(npx semantic-release --dry-run 2>&1)
+          semantic_release_output=$(npx semantic-release --dry-run)
           semantic_release_exit_code=$?
           echo "Semantic Release exit code: $semantic_release_exit_code"
 


### PR DESCRIPTION
The redirection of stderr to stdout in the semantic-release command has been removed. This change ensures that any error messages or output from the command are correctly displayed in the console.