### PR TITLE
🔧 chore(release.yml): remove build step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Build Extension
-        run: npm run build
-        working-directory: ${{github.workspace}}
-
       - name: Run Semantic Release
         env:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/release.config.cjs
+++ b/release.config.cjs
@@ -24,7 +24,7 @@ module.exports = {
 		[
 			"@semantic-release/exec",
 			{
-				successCmd: 'npm version ${nextRelease.version} -m "chore(release): ${nextRelease.version}"'
+				verifyReleaseCmd: 'npm version ${nextRelease.version} -m "chore(release): ${nextRelease.version}";npm run build'
 			}
 		]
 	],


### PR DESCRIPTION
🔧 chore(release.config.cjs): add build step to verifyReleaseCmd in semantic-release configuration The build step has been removed from the release workflow in order to separate the build process from the release process. The build step has been added to the verifyReleaseCmd in the semantic-release configuration to ensure that the project is built before the release is created. This ensures that the release is based on the latest build of the project.