### PR TITLE
fix: handle `yt-navigate-finish` event

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -72,5 +72,19 @@ declare global {
 		i18nextInstance: i18nInstanceType;
 		webkitAudioContext: AudioContext;
 	}
+
+	/**
+	 * Type definitions for the `yt-navigate-finish` event
+	 *
+	 * @abstract
+	 */
+	// TODO: Add exhaustive type definitions
+	interface YoutubeNavigateEvent extends Event {
+		detail?: {
+			endpoint: unknown;
+			pageType: string;
+		};
+	}
 }
+
 export {};

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -72,19 +72,6 @@ declare global {
 		i18nextInstance: i18nInstanceType;
 		webkitAudioContext: AudioContext;
 	}
-
-	/**
-	 * Type definitions for the `yt-navigate-finish` event
-	 *
-	 * @abstract
-	 */
-	// TODO: Add exhaustive type definitions
-	interface YoutubeNavigateEvent extends Event {
-		detail?: {
-			endpoint: unknown;
-			pageType: string;
-		};
-	}
 }
 
 export {};

--- a/src/pages/content/index.tsx
+++ b/src/pages/content/index.tsx
@@ -102,36 +102,38 @@ const enableFeatures = () => {
 		// Wait for the specified container selectors to be available on the page
 		await waitForAllElements(["div#player", "div#player-wide-container", "div#video-container", "div#player-container"]);
 		eventManager.removeAllEventListeners(["featureMenu"]);
-		void enableHideShorts();
-		void removeRedirect();
-		void enableShareShortener();
-		void enableRememberVolume();
-		void enableHideScrollBar();
-		void enableCustomCSS();
+		void Promise.all([
+			enableHideShorts(),
+			removeRedirect(),
+			enableShareShortener(),
+			enableRememberVolume(),
+			enableHideScrollBar(),
+			enableCustomCSS()
+		]);
 
 		// Use a guard clause to reduce amount of times nesting code happens
 		if (!(isWatchPage() || isShortsPage())) return;
 
-		void promptUserToResumeVideo(() => {
-			void setupVideoHistory();
-		});
-		setupPlaybackSpeedChangeListener();
-		void enableShortsAutoScroll();
-		void enableFeatureMenu();
-		void enableOpenYouTubeSettingsOnHover();
-		void enableRememberVolume();
-		void automaticTheaterMode();
-		void setupRemainingTime();
-		void volumeBoost();
-		void setPlayerQuality();
-		void setPlayerSpeed();
-		void openTranscriptButton();
-		void addLoopButton();
-		void addMaximizePlayerButton();
-		void addScreenshotButton();
-		void volumeBoost();
-		void adjustVolumeOnScrollWheel();
-		void adjustSpeedOnScrollWheel();
+		void Promise.all([
+			promptUserToResumeVideo(() => void setupVideoHistory()),
+			setupPlaybackSpeedChangeListener(),
+			enableShortsAutoScroll(),
+			enableFeatureMenu(),
+			enableOpenYouTubeSettingsOnHover(),
+			enableRememberVolume(),
+			automaticTheaterMode(),
+			setupRemainingTime(),
+			volumeBoost(),
+			setPlayerQuality(),
+			setPlayerSpeed(),
+			openTranscriptButton(),
+			addLoopButton(),
+			addMaximizePlayerButton(),
+			addScreenshotButton(),
+			volumeBoost(),
+			adjustVolumeOnScrollWheel(),
+			adjustSpeedOnScrollWheel()
+		]);
 	})();
 };
 

--- a/src/pages/content/index.tsx
+++ b/src/pages/content/index.tsx
@@ -141,6 +141,19 @@ window.addEventListener("DOMContentLoaded", function () {
 		} = response;
 		const i18nextInstance = await i18nService(language);
 		window.i18nextInstance = i18nextInstance;
+
+		// Listen to YouTube's soft navigate event
+		document.addEventListener("yt-navigate-finish", (event: YoutubeNavigateEvent) => {
+			const pageType = event.detail?.pageType;
+			// Only run enableFeatures() if the pageType is either `watch` or `shorts`
+			if (pageType === "watch" || pageType === "shorts") {
+				// Log the console about detecting the soft navigation
+				browserColorLog("Detected a soft navigation to player page, enabling features", "FgMagenta");
+
+				enableFeatures();
+			}
+		});
+
 		if (isWatchPage() || isShortsPage()) {
 			document.addEventListener("yt-navigate-finish", enableFeatures);
 			document.addEventListener("yt-player-updated", enableFeatures);

--- a/src/pages/content/index.tsx
+++ b/src/pages/content/index.tsx
@@ -110,7 +110,7 @@ const enableFeatures = () => {
 		void enableCustomCSS();
 
 		// Use a guard clause to reduce amount of times nesting code happens
-		if (!isWatchPage() || !isShortsPage()) return;
+		if (!(isWatchPage() || isShortsPage())) return;
 
 		void promptUserToResumeVideo(() => {
 			void setupVideoHistory();
@@ -148,7 +148,6 @@ window.addEventListener("DOMContentLoaded", function () {
 		// Listen to YouTube's soft navigate event
 		document.addEventListener("yt-navigate-finish", enableFeatures);
 		document.addEventListener("yt-player-updated", enableFeatures);
-		enableFeatures();
 
 		/**
 		 * Listens for the "yte-message-from-youtube" event and handles incoming messages from the YouTube page.

--- a/src/pages/content/index.tsx
+++ b/src/pages/content/index.tsx
@@ -97,43 +97,46 @@ const alwaysShowProgressBar = async function () {
 	progressLoad += progressWidth;
 };
 
+const enableFeatures = () => {
+	void (async () => {
+		// Wait for the specified container selectors to be available on the page
+		await waitForAllElements(["div#player", "div#player-wide-container", "div#video-container", "div#player-container"]);
+		eventManager.removeAllEventListeners(["featureMenu"]);
+		void enableHideShorts();
+		void removeRedirect();
+		void enableShareShortener();
+		void enableRememberVolume();
+		void enableHideScrollBar();
+		void enableCustomCSS();
+
+		// Use a guard clause to reduce amount of times nesting code happens
+		if (!isWatchPage() || !isShortsPage()) return;
+
+		void promptUserToResumeVideo(() => {
+			void setupVideoHistory();
+		});
+		setupPlaybackSpeedChangeListener();
+		void enableShortsAutoScroll();
+		void enableFeatureMenu();
+		void enableOpenYouTubeSettingsOnHover();
+		void enableRememberVolume();
+		void automaticTheaterMode();
+		void setupRemainingTime();
+		void volumeBoost();
+		void setPlayerQuality();
+		void setPlayerSpeed();
+		void openTranscriptButton();
+		void addLoopButton();
+		void addMaximizePlayerButton();
+		void addScreenshotButton();
+		void volumeBoost();
+		void adjustVolumeOnScrollWheel();
+		void adjustSpeedOnScrollWheel();
+	})();
+};
+
 window.addEventListener("DOMContentLoaded", function () {
 	void (async () => {
-		const enableFeatures = () => {
-			void (async () => {
-				// Wait for the specified container selectors to be available on the page
-				await waitForAllElements(["div#player", "div#player-wide-container", "div#video-container", "div#player-container"]);
-				eventManager.removeAllEventListeners(["featureMenu"]);
-				void enableHideShorts();
-				void removeRedirect();
-				void enableShareShortener();
-				void enableRememberVolume();
-				void enableHideScrollBar();
-				void enableCustomCSS();
-				if (isWatchPage() || isShortsPage()) {
-					void promptUserToResumeVideo(() => {
-						void setupVideoHistory();
-					});
-					setupPlaybackSpeedChangeListener();
-					void enableShortsAutoScroll();
-					void enableFeatureMenu();
-					void enableOpenYouTubeSettingsOnHover();
-					void enableRememberVolume();
-					void automaticTheaterMode();
-					void setupRemainingTime();
-					void volumeBoost();
-					void setPlayerQuality();
-					void setPlayerSpeed();
-					void openTranscriptButton();
-					void addLoopButton();
-					void addMaximizePlayerButton();
-					void addScreenshotButton();
-					void volumeBoost();
-					void adjustVolumeOnScrollWheel();
-					void adjustSpeedOnScrollWheel();
-				}
-			})();
-		};
 		const response = await waitForSpecificMessage("language", "request_data", "content");
 		if (!response) return;
 		const {
@@ -143,23 +146,10 @@ window.addEventListener("DOMContentLoaded", function () {
 		window.i18nextInstance = i18nextInstance;
 
 		// Listen to YouTube's soft navigate event
-		document.addEventListener("yt-navigate-finish", (event: YoutubeNavigateEvent) => {
-			const pageType = event.detail?.pageType;
-			// Only run enableFeatures() if the pageType is either `watch` or `shorts`
-			if (pageType === "watch" || pageType === "shorts") {
-				// Log the console about detecting the soft navigation
-				browserColorLog("Detected a soft navigation to player page, enabling features", "FgMagenta");
+		document.addEventListener("yt-navigate-finish", enableFeatures);
+		document.addEventListener("yt-player-updated", enableFeatures);
+		enableFeatures();
 
-				enableFeatures();
-			}
-		});
-
-		if (isWatchPage() || isShortsPage()) {
-			document.addEventListener("yt-navigate-finish", enableFeatures);
-			document.addEventListener("yt-player-updated", enableFeatures);
-		} else {
-			enableFeatures();
-		}
 		/**
 		 * Listens for the "yte-message-from-youtube" event and handles incoming messages from the YouTube page.
 		 *


### PR DESCRIPTION
## This PR implements a potential fix for #349

Handle the `yt-navigate-finish` event by running a page update check function, if it is able to determine that the page is a watch or shorts page; run `enableFeatures()`.

> TODO: Add exhaustive type definitions to `YoutubeNavigateEvent` interface in the global type definitions