### PR TITLE
Fix layout issue with Watch Later playlists

### DIFF
--- a/src/features/playlistLength/utils.ts
+++ b/src/features/playlistLength/utils.ts
@@ -17,8 +17,7 @@ import {
 const NO_PADDING_HEADER_SELECTOR = "yt-page-header-view-model.yt-page-header-view-model.yt-page-header-view-model--no-padding";
 const CINEMATIC_HEADER_SELECTOR =
 	"yt-page-header-renderer yt-page-header-view-model.yt-page-header-view-model--cinematic-container-overflow-boundary";
-const IMMERSIVE_HEADER_SELECTOR =
-	"ytd-playlist-header-renderer .immersive-header-container .immersive-header-content .thumbnail-and-metadata-wrapper";
+const IMMERSIVE_HEADER_SELECTOR = "ytd-playlist-header-renderer .immersive-header-container .immersive-header-content";
 export const getHeaderSelectors = () =>
 	({
 		playlist: (() => {


### PR DESCRIPTION
This fixes an issue where the `yte-playlist-length-ui` element is not positioned correctly between the 720px and 1080px breakpoints.

This appears to only affect the Watch Later playlist.