### PR TITLE
Update YouTube.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "tailwindcss-multi": "^0.4.0",
         "vite-plugin-css-injected-by-js": "^3.3.0",
         "webextension-polyfill": "^0.12.0",
-        "youtubei.js": "^16.0.1"
+        "youtubei.js": "github:LuanRT/YouTube.js#pull/1075/head"
       },
       "devDependencies": {
         "@eslint/compat": "^1.2.0",
@@ -15765,8 +15765,7 @@
     },
     "node_modules/youtubei.js": {
       "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/youtubei.js/-/youtubei.js-16.0.1.tgz",
-      "integrity": "sha512-3802bCAGkBc2/G5WUTc0l/bO5mPYJbQAHL04d9hE9PnrDHoBUT8MN721Yqt4RCNncAXdHcfee9VdJy3Fhq1r5g==",
+      "resolved": "git+ssh://git@github.com/LuanRT/YouTube.js.git#170d8d716290fdbceaee416e12843e86598230dc",
       "funding": [
         "https://github.com/sponsors/LuanRT"
       ],

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "tailwindcss-multi": "^0.4.0",
     "vite-plugin-css-injected-by-js": "^3.3.0",
     "webextension-polyfill": "^0.12.0",
-    "youtubei.js": "^16.0.1"
+    "youtubei.js": "github:LuanRT/YouTube.js#pull/1075/head"
   },
   "devDependencies": {
     "@eslint/compat": "^1.2.0",


### PR DESCRIPTION
This fixes video removal from watch history. https://github.com/LuanRT/YouTube.js/pull/1075 can reliably be used until it is merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to use a specific development version of a core library.

---

**Note:** This release contains primarily internal updates with no direct user-facing changes or new features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->