### PR TITLE
Update sidebar for regular playlists after delete

### DIFF
--- a/src/features/playlistManagementButtons/index.ts
+++ b/src/features/playlistManagementButtons/index.ts
@@ -146,6 +146,18 @@ async function removeFromPlaylist(youtube: Innertube, playlistId: string, setVid
 		})
 	);
 
+	if (response?.data?.frameworkUpdates?.entityBatchUpdate) {
+		document.querySelector("ytd-app")?.dispatchEvent(
+			new CustomEvent("yt-action", {
+				detail: {
+					actionName: "yt-entity-update-command",
+					args: [{ entityUpdateCommand: { entityBatchUpdate: response.data.frameworkUpdates.entityBatchUpdate } }],
+					returnValue: []
+				}
+			})
+		);
+	}
+	
 	if (response?.data?.newHeader?.playlistHeaderRenderer) {
 		document.querySelector("ytd-playlist-header-renderer")?.dispatchEvent(
 			new CustomEvent("yt-new-playlist-header", {


### PR DESCRIPTION
This is needed for regular playlists, while the `yt-new-playlist-header` custom event is still needed for the watch later playlist.

The `yt-update-playlist-action` event is still used for both playlist types but appears legacy, as it only updates the `ytd-playlist-sidebar-primary-info-renderer` model.

```
if (response?.data?.actions?.[1]) {
	document.querySelector("ytd-app")?.dispatchEvent(
		new CustomEvent("yt-action", {
			detail: {
				actionName: "yt-update-playlist-action",
				args: [response.data.actions[1]],
				returnValue: []
			}
		})
	);
}
```