### PR TITLE
Remove redundant code

### DIFF
--- a/src/pages/embedded/index.ts
+++ b/src/pages/embedded/index.ts
@@ -318,10 +318,8 @@ const initialize = function () {
 		window.i18nextInstance = i18nextInstance;
 		if (isFirstLoad) {
 			void enableFeatures();
-			handleSoftNavigate();
-		} else if (!isFirstLoad) {
-			handleSoftNavigate();
 		}
+		handleSoftNavigate();
 		isFirstLoad = false;
 		/**
 		 * Listens for the "yte-message-from-youtube" event and handles incoming messages from the YouTube page.


### PR DESCRIPTION
This is a small change, but it also serves to highlight a race condition during initialization.

For example, when switching between the "Watch later" and "Liked videos", the initialization process can be interrupted. When the `yt-navigate-start` event is dispatched, the initialization process should be reset. Setting `isEnablingFeatures` to false can somewhat mitigate the issue, but it probably isn't a good solution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved initialization logic for embedded pages to ensure navigation handling is consistently registered on every startup, enhancing reliability and code maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->