### PR TITLE
End screen cards flag fix

### DIFF
--- a/src/features/hideEndScreenCards/index.css
+++ b/src/features/hideEndScreenCards/index.css
@@ -1,3 +1,10 @@
-.yte-hide-end-screen-cards {
-	display: none !important;
+div#movie_player {
+  &.yte-hide-end-screen-cards {
+    .ytp-ce-element,
+    .ytp-ce-hide-button-container,
+    .ytp-fullscreen-grid,
+    .html5-endscreen {
+      display: none !important;
+    }
+  }
 }

--- a/src/features/hideEndScreenCards/index.ts
+++ b/src/features/hideEndScreenCards/index.ts
@@ -8,7 +8,7 @@ import { getFeatureIcon, type ToggleIcon } from "@/src/icons";
 import eventManager from "@/src/utils/EventManager";
 
 import "./index.css";
-import { isWatchPage, modifyElementsClassList, waitForAllElements, waitForElement, waitForSpecificMessage } from "@/src/utils/utilities";
+import { isWatchPage, modifyElementClassList, waitForAllElements, waitForElement, waitForSpecificMessage } from "@/src/utils/utilities";
 export async function disableHideEndScreenCards() {
 	if (!isWatchPage()) return;
 	await waitForAllElements(["div#player", "div#player-container"]);
@@ -76,20 +76,20 @@ export const removeHideEndScreenCardsButton: RemoveButtonFunction = async (place
 	eventManager.removeEventListeners("hideEndScreenCardsButton");
 };
 export function isEndScreenCardsHidden(): boolean {
-	const endCards = document.querySelectorAll(".ytp-ce-element.yte-hide-end-screen-cards");
-	return endCards.length > 0;
+	const elem = document.querySelector("div#movie_player.yte-hide-end-screen-cards");
+	return elem !== null;
 }
 function hideEndScreenCards() {
-	modifyElementsClassList("add", "yte-hide-end-screen-cards", [
-		document.querySelector(".ytp-ce-hide-button-container"),
-		...document.querySelectorAll(".ytp-ce-element")
-	]);
+	modifyElementClassList("add", {
+		className: "yte-hide-end-screen-cards",
+		element: document.querySelector("div#movie_player")
+	});
 }
 function showEndScreenCards() {
-	modifyElementsClassList("remove", "yte-hide-end-screen-cards", [
-		document.querySelector(".ytp-ce-hide-button-container"),
-		...document.querySelectorAll(".ytp-ce-element")
-	]);
+	modifyElementClassList("remove", {
+		className: "yte-hide-end-screen-cards",
+		element: document.querySelector("div#movie_player")
+	});
 }
 export const updateHideEndScreenCardsButtonState = (hideEndScreenCardsPlacement: ButtonPlacement, icon: ToggleIcon, checked: boolean) => {
 	if (hideEndScreenCardsPlacement === "feature_menu") {


### PR DESCRIPTION
Put the class for hiding end screen cards on the `div#movie_player` and
specify in the css to hide the relevant descendants. Also including to
hide the ending endscreen as I assume that for most people, those "cards"
are "end screen cards" and not some other "watch more crumbs" or
similar.

The reason for putting the flag on the top class is that the actual end
screen cards don't always have time to be loaded before the relevant
code is executed and thus won't be hidden.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined end-screen card hiding to be scoped to the player container, improving reliability and preventing unintended global hiding.
  * Expanded the set of end-screen UI elements that are hidden when the feature is active for more consistent behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->