### PR TITLE
Fix Watch Later buttons on page navigation

### DIFF
--- a/src/features/saveToWatchLaterButton/index.ts
+++ b/src/features/saveToWatchLaterButton/index.ts
@@ -46,6 +46,12 @@ export async function enableSaveToWatchLaterButton() {
 		return;
 	}
 
+	document.addEventListener("yt-action", async (event) => {
+		if ((event as CustomEvent).detail.actionName === "yt-prepare-page-dispose") {
+			await disableSaveToWatchLaterButton();
+		}
+	});
+
 	const youtube = await Innertube.create({
 		cookie: document.cookie,
 		fetch: (...args) => fetch(...args)


### PR DESCRIPTION
This disables the Watch Later buttons when leaving a page. Otherwise, when navigating from the homepage to subscriptions, the buttons persist and might not get recreated properly. I think this was supposed to be part of the changes a few weeks ago.