### PR TITLE
fix: replace deprecated unload/beforeunload with pagehide event

### DIFF
--- a/src/pages/content/index.ts
+++ b/src/pages/content/index.ts
@@ -139,9 +139,9 @@ document.addEventListener("yte-message-from-youtube", () => {
 				switch (message.type) {
 					case "pageLoaded": {
 						chrome.storage.onChanged.addListener(storageListeners);
-						window.onunload = () => {
+						window.addEventListener("pagehide", () => {
 							chrome.storage.onChanged.removeListener(storageListeners);
-						};
+						});
 						break;
 					}
 					case "setRememberedVolume": {

--- a/src/pages/embedded/index.ts
+++ b/src/pages/embedded/index.ts
@@ -1184,10 +1184,10 @@ if (document.readyState === "loading") {
 	initialize();
 }
 
-window.onbeforeunload = function () {
+window.addEventListener("pagehide", () => {
 	eventManager.removeAllEventListeners();
 	element.remove();
-};
+});
 
 // Error handling
 window.addEventListener("error", (event) => {


### PR DESCRIPTION
## Summary

- Replace `window.onunload` in the content script and `window.onbeforeunload` in the embedded script with `pagehide` event listeners
- The `unload` and `beforeunload` events violate YouTube's `Permissions-Policy` header, producing console violations on every page load
- `pagehide` is the [recommended modern alternative](https://developer.chrome.com/blog/page-lifecycle-api/#the-unload-event) for page teardown/cleanup tasks

## Changes

- `src/pages/content/index.ts`: `window.onunload` → `window.addEventListener("pagehide", ...)`
- `src/pages/embedded/index.ts`: `window.onbeforeunload` → `window.addEventListener("pagehide", ...)`

## Test plan

- [ ] Load the extension in Chrome/Firefox
- [ ] Open YouTube and navigate to any video
- [ ] Verify no `Permissions policy violation: unload` errors appear in the console from the extension (remaining ones should only come from YouTube's own `kevlar_base_module`)
- [ ] Navigate away from the page and verify cleanup still works (event listeners removed, element removed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced page lifecycle event handling to use more reliable timing mechanisms for cleanup operations when pages transition or close. This ensures better resource management during page unload scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->